### PR TITLE
Added Andrew Ng Blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Pull requests are encouraged. See CONTRIBUTING.md for more details.
  - Richard Lipton & Ken Reagan: [A big result on graph isomorphism](https://rjlipton.wordpress.com/2015/11/04/a-big-result-on-graph-isomorphism/)
  - Scott Aaronson: [The 8000th Busy Beaver number eludes ZF set theory](http://www.scottaaronson.com/blog/?p=2725)
  - Andrew Ng: [ayn blog](http://blog.andrewng.com/)
+ - Adrian Colyer: [The Morning Paper](https://blog.acolyer.org/)
 
 ## Economics
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Pull requests are encouraged. See CONTRIBUTING.md for more details.
 
  - Richard Lipton & Ken Reagan: [A big result on graph isomorphism](https://rjlipton.wordpress.com/2015/11/04/a-big-result-on-graph-isomorphism/)
  - Scott Aaronson: [The 8000th Busy Beaver number eludes ZF set theory](http://www.scottaaronson.com/blog/?p=2725)
+ - Andrew Ng: [ayn blog](http://blog.andrewng.com/)
 
 ## Economics
 


### PR DESCRIPTION
Andrew Ng is VP & Chief Scientist of Baidu; Co-Chairman and Co-Founder of Coursera; and an Adjunct Professor at Stanford University.  In 2011 he led the development of Stanford University’s main MOOC (Massive Open Online Courses) platform and also taught an online Machine Learning class that was offered to over 100,000 students, leading to the founding of Coursera.