### PR TITLE
climate science: Real Climate

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Pull requests are encouraged. See CONTRIBUTING.md for more details.
 
  - Richard Lipton & Ken Reagan: [A big result on graph isomorphism](https://rjlipton.wordpress.com/2015/11/04/a-big-result-on-graph-isomorphism/)
  - Scott Aaronson: [The 8000th Busy Beaver number eludes ZF set theory](http://www.scottaaronson.com/blog/?p=2725)
+ 
+ ## Counterintelligence & terror
+ - John Schindler: [The XX Committee](https://20committee.com/) Schindler is a contentious figure but as former NSA counterintelligence officer and PhD historian for NSA he knows his stuff.
 
 ## Economics
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Pull requests are encouraged. See CONTRIBUTING.md for more details.
  - Andreessen-Horowitz (et al.): [16 Definitions on the Economics of VC](http://a16z.com/2016/09/11/vc-economics/)
  - Patrick McKenzie: [Salary Negotiation: Make More Money, Be More Valued](http://www.kalzumeus.com/2012/01/23/salary-negotiation/)
 
+## Climate Science
+
+ - [Real Climate: Climate Science by Climate Scientists](http://www.realclimate.org)
+ 
 ## Computer science
 
  - Richard Lipton & Ken Reagan: [A big result on graph isomorphism](https://rjlipton.wordpress.com/2015/11/04/a-big-result-on-graph-isomorphism/)


### PR DESCRIPTION
Real Climate is "the granddaddy of climate blogs" -- see #1 in https://thinkprogress.org/top-ten-climate-change-blogs-7a3dc53ceb80#.1q4t2se2k